### PR TITLE
Fix NPM high severity vulnerabilities warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.1.0-alpine AS builder
+FROM node:19.8.1-alpine AS builder
 
 WORKDIR /build
 COPY . .
@@ -13,7 +13,7 @@ RUN npm install && \
     mv node_modules /app
 
 
-FROM node:16.1.0-alpine
+FROM node:19.8.1-alpine
 
 ENV DOCKERIZED=1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hybooru",
-	"version": "1.6.1-dev",
+	"version": "1.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hybooru",
-			"version": "1.6.1-dev",
+			"version": "1.7.1",
 			"dependencies": {
 				"@octokit/core": "^4.1.0",
 				"axios": "^0.21.1",
@@ -5770,9 +5770,9 @@
 			}
 		},
 		"node_modules/handlebars-loader/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -6516,9 +6516,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10131,9 +10131,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -10417,9 +10417,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/webpack": {
-			"version": "5.75.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+			"version": "5.76.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+			"integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -14959,9 +14959,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -15500,9 +15500,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
 		},
 		"jsx-ast-utils": {
 			"version": "3.3.3",
@@ -18085,9 +18085,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -18292,9 +18292,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"webpack": {
-			"version": "5.75.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+			"version": "5.76.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+			"integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",


### PR DESCRIPTION
Fixes part of #26.

Fixed the vulnerability warnings with
```
npm audit fix
npm i --save
```
and updated the node version from 16.1.0 to 19.8.1 in `Dockerfile`.

Also, I've bumped the Hybooru version in `package-lock.json` from `1.6.1.dev` to `1.7.1`. Not sure if it's a good thing or not, I have no experience with NodeJS!