### PR TITLE
Add ogv.js player

### DIFF
--- a/client/components/OgvPlayer.tsx
+++ b/client/components/OgvPlayer.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef } from "react";
+
+export interface OgvPlayerProps {
+  src: string;
+  width?: number;
+  height?: number;
+  controls?: boolean;
+  autoplay?: boolean;
+  muted?: boolean;
+}
+
+export default function OgvPlayer({ src, width, height, muted }: OgvPlayerProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  
+  useEffect(() => {
+    const container = ref.current;
+    if(!container) return;
+    
+    let canceled = false;
+    let player: any = null;
+    
+    (async () => {
+      // @ts-ignore
+      const ogv = await import("ogv");
+      if(canceled) return;
+      ogv.OGVLoader.base = '/static/ogv';
+      player = new ogv.OGVPlayer();
+      container.replaceChildren(player);
+      player.src = src;
+      player.muted = muted;
+      player.play();
+      player.addEventListener('ended', () => {
+        player.play();
+      });
+      player.addEventListener('click', () => {
+        if(player.error) {
+          console.error(`Player encountered error: ${player.error.message}; resetting.`);
+          player.stop();
+        }
+        if(!player.paused) {
+          player.pause();
+        } else {
+          player.play();
+        }
+      });
+      player.addEventListener('dblclick', () => {
+        if(!document.fullscreenElement) {
+          player.requestFullscreen();
+        } else if(document.exitFullscreen) {
+          document.exitFullscreen();
+        }
+      });
+      player.style.width = width + "px";
+      player.style.height = height + "px";
+      player.style.maxWidth = "100%";
+      player.style.maxHeight = "100%";
+    })();
+    
+    return () => {
+      canceled = true;
+      if(player) player.remove();
+    };
+  }, [src, height, width, muted]);
+  
+  return <div className="OgvPlayer" ref={ref} />;
+}

--- a/client/routes/post/File.tsx
+++ b/client/routes/post/File.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useReducer } from "react";
+import React, { useReducer } from "react";
 import { Post, PostNote, PostSummary } from "../../../server/routes/apiTypes";
 import { fileUrl, Mime } from "../../../server/helpers/consts";
 import { classJoin, parseSize } from "../../helpers/utils";
 import useConfig from "../../hooks/useConfig";
 import useSSR from "../../hooks/useSSR";
 import Ruffle from "../../components/Ruffle";
+import OgvPlayer from "../../components/OgvPlayer";
 import "./File.scss";
 
 interface FileProps {
@@ -77,13 +78,19 @@ export default function File({ post, link, className, controls = true, autoPlay 
     case Mime.UNDETERMINED_MP4:
     case Mime.GENERAL_VIDEO:
     case Mime.GENERAL_ANIMATION: {
+      const ogvSupportsFile = mime === Mime.VIDEO_WEBM || mime === Mime.VIDEO_OGV;
+      const useOgv = ogvSupportsFile && document.createElement("video").canPlayType('video/webm') === "";
+      const player = useOgv ?
+        <OgvPlayer src={fileUrl(post)} controls={controls} autoplay={autoPlay} muted={muted}
+                   width={width} height={height} /> :
+        <video className="video" controls={controls} autoPlay={autoPlay} loop muted={muted}
+               width={width} height={height} onError={setError} {...rest}>
+          <source src={fileUrl(post)} />
+          Your browser does not support this video.
+        </video>;
       return (
         <FileWrap className={className} width={width} height={height} link={controls ? undefined : link} notes={notes}>
-          <video className="video" controls={controls} autoPlay={autoPlay} loop muted={muted}
-                 width={width} height={height} onError={setError} {...rest}>
-            <source src={fileUrl(post)} />
-            Your browser does not support this video.
-          </video>
+          {player}
         </FileWrap>
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"express-promise-router": "^4.1.0",
 				"morgan": "^1.10.0",
 				"node-object-hash": "^2.3.1",
+				"ogv": "^1.8.9",
 				"pg": "^8.5.1",
 				"pg-copy-streams": "^5.1.1",
 				"prop-types": "^15.7.2",
@@ -7885,6 +7886,14 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
 			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+		},
+		"node_modules/ogv": {
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/ogv/-/ogv-1.8.9.tgz",
+			"integrity": "sha512-tQA2E3E2PzdWqxIaI5X8q8Vxvj1Ap3JSZmD1MfnA+cTY3o0t+06zY4RKXckQ9pxeqGy/UH4l4QensssmbPLwAQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.7"
+			}
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -17013,6 +17022,14 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
 			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+		},
+		"ogv": {
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/ogv/-/ogv-1.8.9.tgz",
+			"integrity": "sha512-tQA2E3E2PzdWqxIaI5X8q8Vxvj1Ap3JSZmD1MfnA+cTY3o0t+06zY4RKXckQ9pxeqGy/UH4l4QensssmbPLwAQ==",
+			"requires": {
+				"@babel/runtime": "^7.16.7"
+			}
 		},
 		"on-finished": {
 			"version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"express-promise-router": "^4.1.0",
 		"morgan": "^1.10.0",
 		"node-object-hash": "^2.3.1",
+		"ogv": "^1.8.9",
 		"pg": "^8.5.1",
 		"pg-copy-streams": "^5.1.1",
 		"prop-types": "^15.7.2",

--- a/static/ogv
+++ b/static/ogv
@@ -1,0 +1,1 @@
+../node_modules/ogv/dist


### PR DESCRIPTION
Hi! There's a dumb company out there that makes portable computers that can't play Theora/VP8/VP9/etc. It can not be enabled or installed, even if you paid the full cost of the computer! Of course, you should not buy a computer like that, that would be stupid but, unfortunately, I have a computer like that already! I promise I will not buy another computer with such a silly limitation, I made a mistake.

But we should try to save dumb computers from landfills. It is a shame for a computer to get thrown away for this. It is the company that is trash, not the computer!

Therefore, I have attempted to integrate the ogv.js player into Hybooru, to allow me to view very important videos even on my dumbest computers. I have tested and found even very large video can play quite well on the dumb computer using ogv.js. Who knew?

The PR adds:

- Small diversion in File.tsx to decide to load ogv.js player in stead of video tag. Dumb computer detection is accomplished using HTML Video canPlayType function.
- Integration of ogv.js library code using symlink to node_modules, just like Ruffle integration.
- Simple ogv player component. Ogv.js do not come with player chrome so I only added simple play/pause/fullscreen.

I think we could add full player chrome but video.js seems bloated so I decided it would probably be better if we make it by hand. But, getting WebM video to play first seems better to start.

Maybe it would also be a good idea to add ability to set Ogv.js preference, "Always", "Auto-detect", "Never"?

Let me know what you think!