### PR TITLE
Add DB config env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Hybooru's config is stored in `configs.json` file in the project's root director
 | adminPassword                | string or null            | `null`                                            | Password used to regenerate database (can be accessed from the cog button). Null disables manual database regeneration. You can also use environmental variable `HYDRUS_ADMIN_PASSWORD` to override the password |
 | isTTY                        | boolean or null           | `null`                                            | Overrides colorful/fancy output. `true` forces, `false` disables, `null` automatically determines. Useful when piping output.                                                                                    |
 | importBatchSize              | number                    | `8192`                                            | Base batch size used during importing. Decrease it if hybooru crashes during import.                                                                                                                             |
-| db                           | PoolConfig                | _local database_                                  | node-postgres config object. See https://node-postgres.com/apis/client for more details. By defaults it attempts to connect to `hybooru` database at `localhost` using `hybooru` as password.                    |
+| db                           | PoolConfig                | _local database_                                  | node-postgres config object. See https://node-postgres.com/apis/client for more details. By defaults it attempts to connect to `hybooru` database at `localhost` using `hybooru` as password. Can be overridden with `DB_*` environment variables (see below). |
 | posts                        | object                    | _see below_                                       | Options related to posts and files.                                                                                                                                                                              |
 | posts.services               | (string/number)[] or null | `null`                                            | List of names or ids of file services to import. Use `null` to import from all services.                                                                                                                         |
 | posts.filesPathOverride      | string or null            | `null`                                            | Overrides location of post's files. If `null`, `client_files` inside hydrus's db folder is used.                                                                                                                 |
@@ -130,7 +130,22 @@ Hybooru's config is stored in `configs.json` file in the project's root director
 | versionCheck.repo            | string                    | `"hybooru"`                                       | GitHub handle of the repo name. Do not change unless you know what you are doing.                                                                                                                                |
 | versionCheck.cacheLifeMs     | number                    | `3600000` (1 hour)                                | Lifetime of versions cache. GitHub API is rate-limited, do not change unless you know what you are doing.                                                                                                        |
 
-You can also use `PORT` and `HOST` environmental variables to override `port` and `host` config values.
+### Environment Variables
+
+The following environment variables can be used to override config values:
+
+| Variable               | Overrides         | Description                          |
+|------------------------|-------------------|--------------------------------------|
+| `PORT`                 | `port`            | HTTP server port                     |
+| `HOST`                 | `host`            | HTTP server host                     |
+| `HYDRUS_ADMIN_PASSWORD`| `adminPassword`   | Password for database regeneration   |
+| `DB_HOST`              | `db.host`         | Database hostname                    |
+| `DB_PORT`              | `db.port`         | Database port                        |
+| `DB_USER`              | `db.user`         | Database username                    |
+| `DB_PASSWORD`          | `db.password`     | Database password                    |
+| `DB_NAME`              | `db.database`     | Database name                        |
+
+Environment variables take precedence over `configs.json` values.
 
 ## Translation/overlay notes
 

--- a/server/helpers/configs.ts
+++ b/server/helpers/configs.ts
@@ -155,6 +155,27 @@ if(process.env.HYDRUS_ADMIN_PASSWORD) {
   configs.adminPassword = process.env.HYDRUS_ADMIN_PASSWORD;
 }
 
+if(process.env.DB_HOST) {
+  configs.db.host = process.env.DB_HOST;
+}
+if(process.env.DB_PORT) {
+  const port = parseInt(process.env.DB_PORT, 10);
+  if(isNaN(port)) {
+    console.error(`${chalk.bold.yellow("Warning!")} DB_PORT environment variable is not a valid number: ${JSON.stringify(process.env.DB_PORT)}, ignoring.`);
+  } else {
+    configs.db.port = port;
+  }
+}
+if(process.env.DB_USER) {
+  configs.db.user = process.env.DB_USER;
+}
+if(process.env.DB_PASSWORD) {
+  configs.db.password = process.env.DB_PASSWORD;
+}
+if(process.env.DB_NAME) {
+  configs.db.database = process.env.DB_NAME;
+}
+
 if(configs.posts.thumbnailsMode !== ThumbnailsMode.FIT && configs.posts.thumbnailsMode !== ThumbnailsMode.FILL) {
   console.error(`${chalk.bold.yellow("Warning!")} Config option posts.thumbnailsMode should be "fit" or "fill", got ${JSON.stringify(configs.posts.thumbnailsMode)}!`);
   configs.posts.thumbnailsMode = "fit";


### PR DESCRIPTION
Enables users to use environment variables to set/override database values instead of hard-coding them in a plain text file.