### PR TITLE
Fix RNG

### DIFF
--- a/server/controllers/posts.ts
+++ b/server/controllers/posts.ts
@@ -104,7 +104,6 @@ export async function random(query: string | null = null): Promise<PostSummary |
     const post: { id: number } | null = await db.queryFirst(SQL`
       SELECT id
       FROM posts
-      ORDER BY id
       OFFSET floor(random() * (SELECT posts FROM global))
       LIMIT 1
     `);


### PR DESCRIPTION
I noticed a bug when using the filtered random button where the selected posts would always be in the first few hundreds, seemingly not selecting the later ones at all.

After investigating the issue, it looks like the current method for selecting posts only does so on the cached pages (`pageSize * cachePages` first posts), which seems like undesired behavior. This fixes it by choosing an offset from the total number of posts.
From the few tests I've done it works as expected.

While I was in this file, I noticed a minor bug with the query: using OFFSET + LIMIT without an ORDER_BY can lead to underfined behavior (https://www.postgresql.org/docs/current/queries-order.html#QUERIES-ORDER).
I'm not 100% sure this can cause a bug in practice, but might as well follow the manual.