### PR TITLE
Improve handling of client disconnection

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -38,9 +38,13 @@ app.use((req, res, next) => {
 });
 
 app.use((err: Partial<HTTPError>, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  if((err as any).code === 'ECONNABORTED') return;
+
   if((err as any).code === 'EBADCSRFTOKEN') err = new HTTPError(403, "Bad CSRF Token");
   if(err.HTTPcode !== 404) console.error(err);
-  
+
+  if(res.headersSent) return;
+
   const code = err.HTTPcode || 500;
   const error = {
     code,

--- a/server/middlewares/reactMiddleware.tsx
+++ b/server/middlewares/reactMiddleware.tsx
@@ -61,6 +61,8 @@ declare global {
 
 export default function reactMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
   res.react = (initialData, options) => {
+    if(res.headersSent) return res;
+
     res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
     res.header('Expires', '-1');
     res.header('Pragma', 'no-cache');

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -48,8 +48,12 @@ router.use((_req, _res) => {
 });
 
 router.use((err: Partial<HTTPError>, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  if((err as any).code === 'ECONNABORTED') return;
+
   console.error(err);
-  
+
+  if(res.headersSent) return;
+
   const code = err.HTTPcode || 500;
   const error = {
     code,

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -16,6 +16,7 @@ router.get<{ filename: string }>("/:filename", async (req, res, next) => {
   
   res.sendFile(filename, { root }, err => {
     if(err && (err as any).code === 'ENOENT') next(new HTTPError(404));
+    else if(err && (err as any).code === 'ECONNABORTED') return;
     else if(err) next(err);
   });
 });


### PR DESCRIPTION
I often get this kind of error logs on main:
```
Error: Request aborted
  at onaborted (/app/node_modules/express/lib/response.js:1052:15)
  at Immediate.<anonymous> (/app/node_modules/express/lib/response.js:1094:9)
  at processImmediate (node:internal/timers:483:21) {
    code: 'ECONNABORTED'
  }
  Error: Cannot set headers after they are sent to the client
  at ServerResponse.setHeader (node:_http_outgoing:655:11)
  at ServerResponse.header (/app/node_modules/express/lib/response.js:794:10)
  at ServerResponse.react (/build/server/middlewares/reactMiddleware.tsx:64:9)
  at /build/server/app.ts:50:20
  at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:71:5)
  at trim_prefix (/app/node_modules/express/lib/router/index.js:326:13)
  at /app/node_modules/express/lib/router/index.js:286:9
  at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)
  at next (/app/node_modules/express/lib/router/index.js:280:10)
  at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:67:12)
```
This PR fixes that by better handling ECONNABORTED and already-sent requests headers.

I've tested it for about an hour and didn't see those kind of logs anymore.